### PR TITLE
Server tick improvements

### DIFF
--- a/templates/base/server/.rtag/methods.ts.hbs
+++ b/templates/base/server/.rtag/methods.ts.hbs
@@ -23,6 +23,6 @@ export interface Methods<T> {
   {{/each}}
   getUserState(state: T, user: UserData): UserState;
   {{#if tick}}
-  onTick(state: T, ctx: Context): void;
+  onTick(state: T, ctx: Context, timeDelta: number): void;
   {{/if}}
 }

--- a/templates/base/server/.rtag/store.ts.hbs
+++ b/templates/base/server/.rtag/store.ts.hbs
@@ -28,9 +28,6 @@ export default class Store {
     onNewUserState: (stateId: StateId, user: UserData, userState: UserState, results: Record<string, Result>) => void
   ) {
     setInterval(() => {
-      {{#if tick}}
-      states.forEach((state) => impl.onTick(state, ctx()));
-      {{/if}}
       changedStates.forEach((stateId) => {
         subscriptions
           .get(stateId)!
@@ -40,7 +37,16 @@ export default class Store {
       });
       changedStates.clear();
       userResults.clear();
+    }, 100);
+
+    {{#if tick}}
+    let prevUpdateTime = Date.now();
+    setInterval(() => {
+      const currTime = Date.now();
+      states.forEach((state) => impl.onTick(state, ctx(), (currTime - prevUpdateTime) / 1000));
+      prevUpdateTime = currTime;
     }, 50);
+    {{/if}}
   }
   newState(stateId: StateId, user: UserData, req: {{makeRequestName initialize}}) {
     const state = impl.{{initialize}}(user, ctx(), req);


### PR DESCRIPTION
- add `timeDelta` parameter to `onTick` for framerate independence
- separate out server send loop from server update loop
- reduce server send rate from 20hz -> 10hz (update rate remains at 20hz)