### PR TITLE
Rework method responses

### DIFF
--- a/examples/avalon/server/impl.ts
+++ b/examples/avalon/server/impl.ts
@@ -69,11 +69,11 @@ export class Impl implements Methods<InternalState> {
   }
   joinGame(state: InternalState, user: UserData, ctx: Context, request: IJoinGameRequest): Result {
     state.players.push(user.name);
-    return Result.success();
+    return Result.modified();
   }
   startGame(state: InternalState, user: UserData, ctx: Context, request: IStartGameRequest): Result {
     if (!QUEST_CONFIGURATIONS.has(state.players.length)) {
-      return Result.error("Invalid number of players");
+      return Result.unmodified("Invalid number of players");
     }
     if (request.playerOrder !== undefined && request.playerOrder.length > 0) {
       state.players = request.playerOrder;
@@ -83,12 +83,12 @@ export class Impl implements Methods<InternalState> {
     const leader = request.leader ?? state.players[ctx.randInt(state.players.length)];
     state.roles = new Map(shuffle(ctx.randInt, request.roleList).map((role, i) => [state.players[i], role]));
     state.quests.push(createQuest(1, 1, state.players.length, leader));
-    return Result.success();
+    return Result.modified();
   }
   proposeQuest(state: InternalState, user: UserData, ctx: Context, request: IProposeQuestRequest): Result {
     const quest = state.quests.find((q) => q.id === request.questId)!;
     quest.members = request.proposedMembers;
-    return Result.success();
+    return Result.modified();
   }
   voteForProposal(state: InternalState, user: UserData, ctx: Context, request: IVoteForProposalRequest): Result {
     const quest = state.quests.find((q) => q.id === request.questId)!;
@@ -103,7 +103,7 @@ export class Impl implements Methods<InternalState> {
         )
       );
     }
-    return Result.success();
+    return Result.modified();
   }
   voteInQuest(state: InternalState, user: UserData, ctx: Context, request: IVoteInQuestRequest): Result {
     const quest = state.quests.find((q) => q.id === request.questId)!;
@@ -117,7 +117,7 @@ export class Impl implements Methods<InternalState> {
         createQuest(quest.roundNumber + 1, 1, quest.numPlayers, getNextLeader(quest.leader, state.players))
       );
     }
-    return Result.success();
+    return Result.modified();
   }
   getUserState(state: InternalState, user: UserData): PlayerState {
     const role = state.roles.get(user.name);

--- a/examples/avalon/server/impl.ts
+++ b/examples/avalon/server/impl.ts
@@ -1,7 +1,6 @@
-import { Context, Methods } from "./.rtag/methods";
+import { Methods, Context, Result } from "./.rtag/methods";
 import {
   UserData,
-  Result,
   PlayerState,
   ICreateGameRequest,
   IJoinGameRequest,

--- a/templates/base/client/.rtag/app.ts.hbs
+++ b/templates/base/client/.rtag/app.ts.hbs
@@ -61,9 +61,9 @@ Vue.component("method-form", {
         return;
       }
       const client: RtagClient = this.$parent.$data.client;
-      const res: Types.Result = await client[this.method](this.value);
-      if (res.type === "error") {
-        this.$toasted.error(JSON.stringify(res.error));
+      const res: {{error.typeString}} | null = await client[this.method](this.value);
+      if (res !== null) {
+        this.$toasted.error(JSON.stringify(res));
       } else {
         this.value = {};
         this.hack = false;

--- a/templates/base/client/.rtag/app.ts.hbs
+++ b/templates/base/client/.rtag/app.ts.hbs
@@ -61,8 +61,8 @@ Vue.component("method-form", {
         return;
       }
       const client: RtagClient = this.$parent.$data.client;
-      const res: {{error.typeString}} | null = await client[this.method](this.value);
-      if (res !== null) {
+      const res: {{error.typeString}} | undefined = await client[this.method](this.value);
+      if (res !== undefined) {
         this.$toasted.error(JSON.stringify(res));
       } else {
         this.value = {};

--- a/templates/base/client/.rtag/client.ts.hbs
+++ b/templates/base/client/.rtag/client.ts.hbs
@@ -13,7 +13,7 @@ import {
 export type StateId = string;
 
 export class RtagClient {
-  private callbacks: Record<string, (response: {{error.typeString}} | null) => void> = {};
+  private callbacks: Record<string, (response: {{error.typeString}} | undefined) => void> = {};
 
   private constructor(private socket: WebSocket) {}
 
@@ -64,7 +64,7 @@ export class RtagClient {
         onStateChange(state);
         Object.entries(responses).forEach(([msgId, response]) => {
           if (msgId in client.callbacks) {
-            client.callbacks[msgId](response);
+            client.callbacks[msgId](response ?? undefined);
             delete client.callbacks[msgId];
           }
         });
@@ -74,7 +74,7 @@ export class RtagClient {
 
   {{#each methods}}
   {{#if (ne @key ../initialize)}}
-  public {{@key}}(request: {{makeRequestName @key}}): Promise<{{../error.typeString}} | null> {
+  public {{@key}}(request: {{makeRequestName @key}}): Promise<{{../error.typeString}} | undefined> {
     const msgId = Math.random().toString(36).substring(2);
     this.socket.send(encode({ method: "{{@key}}", msgId, args: request }));
     return new Promise((resolve) => {

--- a/templates/base/client/.rtag/client.ts.hbs
+++ b/templates/base/client/.rtag/client.ts.hbs
@@ -59,7 +59,7 @@ export class RtagClient {
       socket.onmessage = ({ data }) => {
         const { state, responses } = decode(data as ArrayBuffer) as {
           state: UserState;
-          responses: Record<string, string | null>;
+          responses: Record<string, {{error.typeString}} | null>;
         };
         onStateChange(state);
         Object.entries(responses).forEach(([msgId, response]) => {

--- a/templates/base/client/.rtag/client.ts.hbs
+++ b/templates/base/client/.rtag/client.ts.hbs
@@ -4,7 +4,6 @@ import jwtDecode from "jwt-decode";
 import { decode, encode } from "@msgpack/msgpack";
 import {
   UserData,
-  Result,
   {{userState}} as UserState,
   {{#each methods}}
   {{makeRequestName @key}},
@@ -14,7 +13,7 @@ import {
 export type StateId = string;
 
 export class RtagClient {
-  private callbacks: Record<string, (result: Result) => void> = {};
+  private callbacks: Record<string, (response: {{error.typeString}} | null) => void> = {};
 
   private constructor(private socket: WebSocket) {}
 
@@ -58,11 +57,14 @@ export class RtagClient {
         reject();
       };
       socket.onmessage = ({ data }) => {
-        const { state, results } = decode(data as ArrayBuffer) as { state: UserState; results: Record<string, Result> };
+        const { state, responses } = decode(data as ArrayBuffer) as {
+          state: UserState;
+          responses: Record<string, string | null>;
+        };
         onStateChange(state);
-        Object.entries(results).forEach(([msgId, result]) => {
+        Object.entries(responses).forEach(([msgId, response]) => {
           if (msgId in client.callbacks) {
-            client.callbacks[msgId](result);
+            client.callbacks[msgId](response);
             delete client.callbacks[msgId];
           }
         });
@@ -72,7 +74,7 @@ export class RtagClient {
 
   {{#each methods}}
   {{#if (ne @key ../initialize)}}
-  public {{@key}}(request: {{makeRequestName @key}}): Promise<Result> {
+  public {{@key}}(request: {{makeRequestName @key}}): Promise<{{../error.typeString}} | null> {
     const msgId = Math.random().toString(36).substring(2);
     this.socket.send(encode({ method: "{{@key}}", msgId, args: request }));
     return new Promise((resolve) => {

--- a/templates/base/client/.rtag/types.ts.hbs
+++ b/templates/base/client/.rtag/types.ts.hbs
@@ -37,20 +37,20 @@ export interface {{capitalize @key}}UserData {
 }
 {{/each}}
 export type UserData = {{#each auth}}{{capitalize @key}}UserData{{#unless @last}} | {{/unless}}{{/each}};
-export interface SuccessResult {
-  type: "success";
+export interface ModifiedResult {
+  type: "modified";
 }
-export interface ErrorResult {
-  type: "error";
-  error: {{> renderArg error}};
+export interface UnmodifiedResult {
+  type: "unmodified";
+  error?: {{> renderArg error}};
 }
-export type Result = SuccessResult | ErrorResult;
-export const Result: { success: () => SuccessResult; error: (error: {{> renderArg error}}) => ErrorResult } = {
-  success: () => ({
-    type: "success",
+export type Result = ModifiedResult | UnmodifiedResult;
+export const Result: { modified: () => ModifiedResult; unmodified: (error?: {{> renderArg error}}) => UnmodifiedResult } = {
+  modified: () => ({
+    type: "modified",
   }),
-  error: (error: {{> renderArg error}}) => ({
-    type: "error",
+  unmodified: (error?: {{> renderArg error}}) => ({
+    type: "unmodified",
     error,
   }),
 };

--- a/templates/base/client/.rtag/types.ts.hbs
+++ b/templates/base/client/.rtag/types.ts.hbs
@@ -37,23 +37,6 @@ export interface {{capitalize @key}}UserData {
 }
 {{/each}}
 export type UserData = {{#each auth}}{{capitalize @key}}UserData{{#unless @last}} | {{/unless}}{{/each}};
-export interface ModifiedResult {
-  type: "modified";
-}
-export interface UnmodifiedResult {
-  type: "unmodified";
-  error?: {{> renderArg error}};
-}
-export type Result = ModifiedResult | UnmodifiedResult;
-export const Result: { modified: () => ModifiedResult; unmodified: (error?: {{> renderArg error}}) => UnmodifiedResult } = {
-  modified: () => ({
-    type: "modified",
-  }),
-  unmodified: (error?: {{> renderArg error}}) => ({
-    type: "unmodified",
-    error,
-  }),
-};
 {{#*inline "renderArg"}}
 {{#if alias}}
 {{typeString}}

--- a/templates/base/server/.rtag/methods.ts.hbs
+++ b/templates/base/server/.rtag/methods.ts.hbs
@@ -1,6 +1,5 @@
 import {
   UserData,
-  Result,
   {{userState}} as UserState,
   {{#each methods}}
   {{makeRequestName @key}},
@@ -12,6 +11,24 @@ export interface Context {
   randInt(limit?: number): number;
   time(): number;
 }
+
+export interface ModifiedResult {
+  type: "modified";
+}
+export interface UnmodifiedResult {
+  type: "unmodified";
+  error?: {{error.typeString}};
+}
+export type Result = ModifiedResult | UnmodifiedResult;
+export const Result: { modified: () => ModifiedResult; unmodified: (error?: {{error.typeString}}) => UnmodifiedResult } = {
+  modified: () => ({
+    type: "modified",
+  }),
+  unmodified: (error?: {{error.typeString}}) => ({
+    type: "unmodified",
+    error,
+  }),
+};
 
 export interface Methods<T> {
   {{#each methods}}

--- a/templates/base/server/.rtag/proxy.ts.hbs
+++ b/templates/base/server/.rtag/proxy.ts.hbs
@@ -8,7 +8,7 @@ import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 import Store from "./store";
 import { authMiddleware, getUserFromToken } from "./auth";
-import { UserData, {{userState}} as UserState, Result } from "./types";
+import { UserData, {{userState}} as UserState } from "./types";
 
 type StateId = string;
 type Connection = WebSocket & { isAlive: boolean };

--- a/templates/base/server/.rtag/proxy.ts.hbs
+++ b/templates/base/server/.rtag/proxy.ts.hbs
@@ -56,7 +56,7 @@ server.on("upgrade", (req: http.IncomingMessage, socket: Socket, head: Buffer) =
   wss.handleUpgrade(req, socket, head, (ws) => {
     ws.once("message", (token) => {
       const user = getUserFromToken(token as string);
-      ws.send(encode({ state: store.getUserState(stateId, user)!, results: {} }, { ignoreUndefined: true }));
+      ws.send(encode({ state: store.getUserState(stateId, user)!, responses: {} }, { ignoreUndefined: true }));
       handleConnection(stateId, user, Object.assign(ws, { isAlive: true }));
     });
   });
@@ -116,10 +116,10 @@ export function onNewUserState(
   stateId: StateId,
   user: UserData,
   userState: UserState,
-  results: Record<string, Result>
+  responses: Record<string, {{error.typeString}} | null>
 ) {
   const client = stateId + user.id;
   connections.get(client)!.forEach((socket) => {
-    socket.send(encode({ state: userState, results }, { ignoreUndefined: true }));
+    socket.send(encode({ state: userState, responses }, { ignoreUndefined: true }));
   });
 }

--- a/templates/base/server/.rtag/store.ts.hbs
+++ b/templates/base/server/.rtag/store.ts.hbs
@@ -20,7 +20,7 @@ type StateId = string;
 type State = ReturnType<typeof impl.{{initialize}}>;
 const states: Map<StateId, State> = new Map();
 const changedStates: Set<StateId> = new Set();
-const userResults: Map<StateId, Map<string, Record<string, Result>>> = new Map();
+const userResponses: Map<StateId, Map<string, Record<string, {{error.typeString}} | null>>> = new Map();
 const subscriptions: Map<StateId, Set<UserData>> = new Map();
 const rng = seedrandom(Math.random().toString());
 
@@ -28,21 +28,21 @@ export default class Store {
   constructor() {
     setInterval(() => {
       changedStates.forEach((stateId) => {
-        const results = userResults.get(stateId);
+        const responses = userResponses.get(stateId);
         subscriptions.get(stateId)!.forEach((user) => {
-          onNewUserState(stateId, user, impl.getUserState(states.get(stateId)!, user), results?.get(user.id) ?? {});
+          onNewUserState(stateId, user, impl.getUserState(states.get(stateId)!, user), responses?.get(user.id) ?? {});
         });
-        userResults.delete(stateId);
+        userResponses.delete(stateId);
       });
-      userResults.forEach((results, stateId) => {
+      userResponses.forEach((responses, stateId) => {
         subscriptions.get(stateId)!.forEach((user) => {
-          if (results.has(user.id)) {
-            onNewUserState(stateId, user, impl.getUserState(states.get(stateId)!, user), results.get(user.id)!);
+          if (responses.has(user.id)) {
+            onNewUserState(stateId, user, impl.getUserState(states.get(stateId)!, user), responses.get(user.id)!);
           }
         });
       });
       changedStates.clear();
-      userResults.clear();
+      userResponses.clear();
     }, 100);
     {{#if tick}}
 
@@ -66,13 +66,14 @@ export default class Store {
   handleUpdate(stateId: StateId, user: UserData, msgId: string, method: string, args: any) {
     const result = getResult(states.get(stateId)!, user, method, args);
     if (result !== undefined) {
-      if (!userResults.has(stateId)) {
-        userResults.set(stateId, new Map([[user.id, { [msgId]: result }]]));
+      const response = result.type === "modified" ? null : result.error ?? null;
+      if (!userResponses.has(stateId)) {
+        userResponses.set(stateId, new Map([[user.id, { [msgId]: response }]]));
       } else {
-        if (!userResults.get(stateId)!.has(user.id)) {
-          userResults.get(stateId)!.set(user.id, { [msgId]: result });
+        if (!userResponses.get(stateId)!.has(user.id)) {
+          userResponses.get(stateId)!.set(user.id, { [msgId]: response });
         } else {
-          userResults.get(stateId)!.get(user.id)![msgId] = result;
+          userResponses.get(stateId)!.get(user.id)![msgId] = response;
         }
       }
     }

--- a/templates/base/server/.rtag/store.ts.hbs
+++ b/templates/base/server/.rtag/store.ts.hbs
@@ -4,7 +4,7 @@ import dependencyTree from "dependency-tree";
 import chokidar from "chokidar";
 import seedrandom from "seedrandom";
 import { onNewUserState } from "./proxy";
-import { UserData, Result, {{makeRequestName initialize}} } from "./types";
+import { UserData, {{makeRequestName initialize}} } from "./types";
 
 const deps = dependencyTree.toList({
   directory: ".",

--- a/templates/base/server/.rtag/types.ts.hbs
+++ b/templates/base/server/.rtag/types.ts.hbs
@@ -37,20 +37,20 @@ export interface {{capitalize @key}}UserData {
 }
 {{/each}}
 export type UserData = {{#each auth}}{{capitalize @key}}UserData{{#unless @last}} | {{/unless}}{{/each}};
-export interface SuccessResult {
-  type: "success";
+export interface ModifiedResult {
+  type: "modified";
 }
-export interface ErrorResult {
-  type: "error";
-  error: {{> renderArg error}};
+export interface UnmodifiedResult {
+  type: "unmodified";
+  error?: {{> renderArg error}};
 }
-export type Result = SuccessResult | ErrorResult;
-export const Result: { success: () => SuccessResult; error: (error: {{> renderArg error}}) => ErrorResult } = {
-  success: () => ({
-    type: "success",
+export type Result = ModifiedResult | UnmodifiedResult;
+export const Result: { modified: () => ModifiedResult; unmodified: (error?: {{> renderArg error}}) => UnmodifiedResult } = {
+  modified: () => ({
+    type: "modified",
   }),
-  error: (error: {{> renderArg error}}) => ({
-    type: "error",
+  unmodified: (error?: {{> renderArg error}}) => ({
+    type: "unmodified",
     error,
   }),
 };

--- a/templates/base/server/.rtag/types.ts.hbs
+++ b/templates/base/server/.rtag/types.ts.hbs
@@ -37,23 +37,6 @@ export interface {{capitalize @key}}UserData {
 }
 {{/each}}
 export type UserData = {{#each auth}}{{capitalize @key}}UserData{{#unless @last}} | {{/unless}}{{/each}};
-export interface ModifiedResult {
-  type: "modified";
-}
-export interface UnmodifiedResult {
-  type: "unmodified";
-  error?: {{> renderArg error}};
-}
-export type Result = ModifiedResult | UnmodifiedResult;
-export const Result: { modified: () => ModifiedResult; unmodified: (error?: {{> renderArg error}}) => UnmodifiedResult } = {
-  modified: () => ({
-    type: "modified",
-  }),
-  unmodified: (error?: {{> renderArg error}}) => ({
-    type: "unmodified",
-    error,
-  }),
-};
 {{#*inline "renderArg"}}
 {{#if alias}}
 {{typeString}}


### PR DESCRIPTION
Impl:
- `Result.success` -> `Result.modified`
- `Result.error` -> `Result.unmodified` (error value is now optional, so users can't tell the difference between `Result.modified()` and `Result.unmodified()`)

Client:
- `Promise<Result>` -> `Promise<{{error | null}}`

The purpose of these changes are to make it more clear to developers what to return inside impl methods, and gives rtag a more robust way to learn about modifications to state (rather than relying on the `on-change` package)