### PR TITLE
Make stateId part of UpdateArgs

### DIFF
--- a/templates/base/client/.hathora/client.ts.hbs
+++ b/templates/base/client/.hathora/client.ts.hbs
@@ -16,7 +16,7 @@ import {
 } from "../../api/types";
 
 export type StateId = string;
-export type UpdateArgs = { state: UserState; updatedAt: number; events: string[] };
+export type UpdateArgs = { stateId: StateId; state: UserState; updatedAt: number; events: string[] };
 
 export class HathoraClient {
   public constructor(public appId: string) {}
@@ -84,7 +84,7 @@ export class HathoraConnection {
     socket.onmessage = ({ data }) => {
       if (this.state === undefined) {
         this.state = decodeStateSnapshot(new Uint8Array(data as ArrayBuffer));
-        onUpdate({ state: JSON.parse(JSON.stringify(this.state)), updatedAt: 0, events: [] });
+        onUpdate({ stateId, state: JSON.parse(JSON.stringify(this.state)), updatedAt: 0, events: [] });
         return;
       }
       const { stateDiff, changedAtDiff, responses, events } = decodeStateUpdate(new Uint8Array(data as ArrayBuffer));
@@ -93,6 +93,7 @@ export class HathoraConnection {
       }
       this.changedAt += changedAtDiff;
       onUpdate({
+        stateId,
         state: JSON.parse(JSON.stringify(this.state)),
         updatedAt: this.changedAt,
         events: events.map((e) => e.event),


### PR DESCRIPTION
Since you don't know the `stateId` yet when calling `client.connectNew` it  makes it hard to make use of `stateId` in `onUpdate`, e.g. for handling multiple possible active games. Here's how I use [this in my project](https://github.com/kasbah/calm-go/blob/7f2e097911f43eb128e5616c9facef4daee7dd6b/client/web/src/AppContext.tsx#L39-L41). 