### PR TITLE
Add a recursive "open" check on callMethod

### DIFF
--- a/templates/base/client/.hathora/client.ts.hbs
+++ b/templates/base/client/.hathora/client.ts.hbs
@@ -124,6 +124,8 @@ export class HathoraConnection {
     return new Promise((resolve, reject) => {
       if (this.socket.readyState === this.socket.CLOSED) {
         reject("Connection is closed");
+      } else if (this.socket.readyState !== this.socket.OPEN) {
+        setTimeout(() => this.callMethod(method, request).then(resolve).catch(reject), 0);
       } else {
         const msgId: Uint8Array = getRandomValues(new Uint8Array(4));
         this.socket.send(new Uint8Array([...new Uint8Array([method]), ...msgId, ...request]));


### PR DESCRIPTION
The way I am using the connection I was getting errors in the console:

Chrome:
```
Uncaught (in promise) DOMException: Failed to execute 'send' on 'WebSocket': Still in CONNECTING state.
```

Firefox:
```
Uncaught (in promise) DOMException: An attempt was made to use an object that is not, or is no longer, usable
```

This solves that. 

- Note the `0` in `setTimeout`, maybe we want a bit of a delay instead
- Maybe an exponential back-off would be better than just a `setTimeout`
- Relevant [StackOverflow answer](https://stackoverflow.com/a/23052382)