### PR TITLE
Remove userId from initialize

### DIFF
--- a/examples/avalon/hathora.yml
+++ b/examples/avalon/hathora.yml
@@ -47,7 +47,6 @@ types:
   PlayerState:
     status: GameStatus
     rolesInfo: RoleInfo[]
-    creator: UserId
     players: UserId[]
     role: Role?
     knownPlayers: UserId[]

--- a/examples/avalon/server/impl.ts
+++ b/examples/avalon/server/impl.ts
@@ -26,7 +26,6 @@ type InternalQuestAttempt = {
 };
 
 type InternalState = {
-  creator: UserId;
   players: UserId[];
   roles: Map<UserId, Role>;
   quests: InternalQuestAttempt[];
@@ -53,8 +52,8 @@ const QUEST_CONFIGURATIONS = new Map([
 ]);
 
 export class Impl implements Methods<InternalState> {
-  initialize(userId: UserId, ctx: Context): InternalState {
-    return { creator: userId, players: [userId], roles: new Map(), quests: [] };
+  initialize(ctx: Context): InternalState {
+    return { players: [], roles: new Map(), quests: [] };
   }
   joinGame(state: InternalState, userId: UserId, ctx: Context, request: IJoinGameRequest): Response {
     if (state.players.find((player) => player === userId) !== undefined) {
@@ -171,7 +170,6 @@ export class Impl implements Methods<InternalState> {
         knownRoles: [...info.knownRoles],
         quantity: roles.filter(([_, r]) => r === rl).length,
       })),
-      creator: state.creator,
       players: state.players,
       role,
       knownPlayers: roles.filter(([_, r]) => knownRoles.has(r)).map(([p, _]) => p),

--- a/examples/chat/hathora.yml
+++ b/examples/chat/hathora.yml
@@ -5,7 +5,6 @@ types:
     sentBy: UserId
     sentTo: UserId?
   RoomState:
-    createdBy: UserId
     users: UserId[]
     messages: Message[]
 

--- a/examples/chat/server/impl.ts
+++ b/examples/chat/server/impl.ts
@@ -10,8 +10,8 @@ import {
 } from "../api/types";
 
 export class Impl implements Methods<RoomState> {
-  initialize(userId: UserId, ctx: Context): RoomState {
-    return { createdBy: userId, users: [userId], messages: [] };
+  initialize(ctx: Context): RoomState {
+    return { users: [], messages: [] };
   }
   joinRoom(state: RoomState, userId: string, ctx: Context, request: IJoinRoomRequest): Response {
     if (state.users.includes(userId)) {
@@ -46,7 +46,6 @@ export class Impl implements Methods<RoomState> {
   }
   getUserState(state: RoomState, userId: UserId): RoomState {
     return {
-      createdBy: state.createdBy,
       users: state.users,
       messages: state.messages.filter(
         (msg) => msg.sentBy === userId || msg.sentTo === userId || msg.sentTo === undefined

--- a/examples/chess/client/prototype-ui/plugins/Board/index.ts
+++ b/examples/chess/client/prototype-ui/plugins/Board/index.ts
@@ -1,17 +1,20 @@
 import { LitElement, html } from "lit";
 import { property } from "lit/decorators.js";
 import { Board, Color, Piece, PieceType, PlayerState } from "../../../../api/types";
+import { UserData } from "../../../../api/base";
 import { HathoraConnection } from "../../../.hathora/client";
 import "chessboard-element";
 
 export default class BoardEl extends LitElement {
   @property() val!: Board;
   @property() state!: PlayerState;
+  @property() user!: UserData;
   @property() client!: HathoraConnection;
 
   render() {
+    const color = this.state.players.find((p) => p.id === this.user.id)?.color;
     return html`<div style="max-width: 400px">
-      <chess-board draggable-pieces orientation=${this.state.color === Color.BLACK ? "black" : "white"}></chess-board>
+      <chess-board draggable-pieces orientation=${color === Color.BLACK ? "black" : "white"}></chess-board>
     </div>`;
   }
 

--- a/examples/chess/hathora.yml
+++ b/examples/chess/hathora.yml
@@ -24,14 +24,16 @@ types:
     color: Color
     type: PieceType
     square: Square
+  Player:
+    id: UserId
+    color: Color
   PlayerState:
     board: Board
     status: GameStatus
-    color: Color
-    opponent: UserId?
+    players: Player[]
 
 methods:
-  startGame:
+  joinGame:
   movePiece:
     from: Square
     to: Square

--- a/examples/codenames/server/impl.ts
+++ b/examples/codenames/server/impl.ts
@@ -24,8 +24,8 @@ type InternalState = {
 };
 
 export class Impl implements Methods<InternalState> {
-  initialize(userId: UserId, ctx: Context): InternalState {
-    return { players: [createPlayer(userId)], currentTurn: Color.YELLOW, cards: [] };
+  initialize(ctx: Context): InternalState {
+    return { players: [], currentTurn: Color.YELLOW, cards: [] };
   }
   joinGame(state: InternalState, userId: UserId, ctx: Context, request: IJoinGameRequest): Response {
     if (getGameStatus(state.cards) !== GameStatus.NOT_STARTED) {

--- a/examples/poker/server/impl.ts
+++ b/examples/poker/server/impl.ts
@@ -25,9 +25,9 @@ type InternalState = {
 };
 
 export class Impl implements Methods<InternalState> {
-  initialize(userId: UserId, ctx: Context): InternalState {
+  initialize(ctx: Context): InternalState {
     return {
-      players: [createPlayer(userId)],
+      players: [],
       dealerIdx: 0,
       activePlayerIdx: 0,
       revealedCards: [],

--- a/examples/pong/server/impl.ts
+++ b/examples/pong/server/impl.ts
@@ -9,15 +9,15 @@ const PADDLE_SPEED = 100;
 const BALL_SPEED = 250;
 
 type InternalState = {
-  playerA: { id: string; direction: Direction; paddle: number; score: number };
+  playerA: { id?: string; direction: Direction; paddle: number; score: number };
   playerB: { id?: string; direction: Direction; paddle: number; score: number };
   ball: { x: number; y: number; angle: number };
 };
 
 export class Impl implements Methods<InternalState> {
-  initialize(userId: UserId, ctx: Context): InternalState {
+  initialize(ctx: Context): InternalState {
     return {
-      playerA: { id: userId, direction: Direction.NONE, paddle: MAP_HEIGHT / 2, score: 0 },
+      playerA: { direction: Direction.NONE, paddle: MAP_HEIGHT / 2, score: 0 },
       playerB: { direction: Direction.NONE, paddle: MAP_HEIGHT / 2, score: 0 },
       ball: { x: MAP_WIDTH / 2, y: MAP_HEIGHT / 2, angle: ctx.chance.floating({ min: 0, max: 2 * Math.PI }) },
     };
@@ -25,17 +25,18 @@ export class Impl implements Methods<InternalState> {
   setDirection(state: InternalState, userId: UserId, ctx: Context, request: ISetDirectionRequest): Response {
     if (state.playerA.id === userId) {
       state.playerA.direction = request.direction;
-      return Response.ok();
     } else if (state.playerB.id === userId) {
       state.playerB.direction = request.direction;
-      return Response.ok();
+    } else if (state.playerA.id === undefined) {
+      state.playerA.id = userId;
+      state.playerA.direction = request.direction;
     } else if (state.playerB.id === undefined) {
       state.playerB.id = userId;
       state.playerB.direction = request.direction;
-      return Response.ok();
     } else {
       return Response.error("Not in game");
     }
+    return Response.ok();
   }
   getUserState(state: InternalState, userId: UserId): PlayerState {
     return state;

--- a/examples/rock-paper-scissor/hathora.yml
+++ b/examples/rock-paper-scissor/hathora.yml
@@ -9,7 +9,7 @@ types:
     gesture: Gesture?
   PlayerState:
     round: int
-    player1: PlayerInfo
+    player1: PlayerInfo?
     player2: PlayerInfo?
 
 methods:

--- a/examples/uno/hathora.yml
+++ b/examples/uno/hathora.yml
@@ -10,7 +10,7 @@ types:
   PlayerState:
     hand: Card[]
     players: UserId[]
-    turn: UserId
+    turn: UserId?
     pile: Card?
     winner: UserId?
 

--- a/templates/base/server/.hathora/methods.ts.hbs
+++ b/templates/base/server/.hathora/methods.ts.hbs
@@ -16,7 +16,7 @@ export interface Context {
 }
 
 export interface Methods<T> {
-  initialize(userId: UserId, ctx: Context): T;
+  initialize(ctx: Context): T;
   {{#each methods}}
   {{@key}}(state: T, userId: UserId, ctx: Context, request: {{makeRequestName @key}}): Response;
   {{/each}}

--- a/templates/base/server/.hathora/store.ts.hbs
+++ b/templates/base/server/.hathora/store.ts.hbs
@@ -55,10 +55,10 @@ class Store {
     const seed = randomBytes(8).readBigUInt64LE();
     const time = Date.now();
     const chance = Chance(seed.toString());
-    const state = await impl.initialize(userId, ctx(chance, time, stateId));
+    const state = await impl.initialize(ctx(chance, time, stateId));
     stateInfo.set(stateId, { state, chance, subscriptions: new Map() });
     sendSnapshot(stateId, userId);
-    log.append(stateId, time, new Writer().writeUInt64(seed).writeString(userId).toBuffer());
+    log.append(stateId, time, new Writer().writeUInt64(seed).toBuffer());
   }
   async subscribeUser(stateId: StateId, userId: UserId) {
     if (!stateInfo.has(stateId)) {
@@ -130,9 +130,8 @@ export async function loadState(stateId: StateId) {
     const { time, record } = rows[0];
     const reader = new Reader(record);
     const seed = reader.readUInt64();
-    const userId = reader.readString();
     const chance = Chance(seed.toString());
-    const state = await impl.initialize(userId, ctxNoEvents(chance, time));
+    const state = await impl.initialize(ctxNoEvents(chance, time));
 
     for (let i = 1; i < rows.length; i++) {
       const { time, record } = rows[i];

--- a/templates/base/server/.hathora/wrapper.ts.hbs
+++ b/templates/base/server/.hathora/wrapper.ts.hbs
@@ -14,9 +14,9 @@ export type State = ReturnType<typeof impl.initialize>;
 let changedAt: number | undefined = undefined;
 
 export const ImplWrapper = {
-  async initialize(userId: UserId, ctx: Context) {
+  async initialize(ctx: Context) {
     await tryReloadImpl();
-    const state = impl.initialize(userId, ctx);
+    const state = impl.initialize(ctx);
     return onChange(state, () => (changedAt = Date.now()));
   },
   async getResult(state: State, userId: UserId, method: Method, ctx: Context, argsBuffer: ArrayBufferView) {


### PR DESCRIPTION
This ensures the `initialize` function is decoupled from who triggered the creation. That makes it easier to support cases where you can create the game but not join it yourself.

Ultimately this is paving the way for matchmaking, where a user isn't directly responsible for creating a game.