### PR TITLE
Add a ping message from store to coordinator every 10s

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -31,8 +31,8 @@ function getProjectRoot(cwd: string): string {
 function getAppConfig() {
   const appSecret = process.env.APP_SECRET ?? uuidv4();
   const appId = createHash("sha256").update(appSecret).digest("hex");
-  const coordinatorHost = process.env.COORDINATOR_HOST ?? "coordinator.hathora.com";
-  const matchmakerHost = process.env.MATCHMAKER_HOST ?? "matchmaker.hathora.com";
+  const coordinatorHost = process.env.COORDINATOR_HOST ?? "coordinator.hathora.dev";
+  const matchmakerHost = process.env.MATCHMAKER_HOST ?? "matchmaker.hathora.dev";
   return { appId, appSecret, coordinatorHost, matchmakerHost };
 }
 

--- a/cli.ts
+++ b/cli.ts
@@ -31,8 +31,8 @@ function getProjectRoot(cwd: string): string {
 function getAppConfig() {
   const appSecret = process.env.APP_SECRET ?? uuidv4();
   const appId = createHash("sha256").update(appSecret).digest("hex");
-  const coordinatorHost = process.env.COORDINATOR_HOST ?? "coordinator.hathora.dev";
-  const matchmakerHost = process.env.MATCHMAKER_HOST ?? "matchmaker.hathora.dev";
+  const coordinatorHost = process.env.COORDINATOR_HOST ?? "coordinator.hathora.com";
+  const matchmakerHost = process.env.MATCHMAKER_HOST ?? "matchmaker.hathora.com";
   return { appId, appSecret, coordinatorHost, matchmakerHost };
 }
 

--- a/templates/base/server/.hathora/protocol.ts.hbs
+++ b/templates/base/server/.hathora/protocol.ts.hbs
@@ -37,7 +37,6 @@ export function register(store: Store): Promise<CoordinatorClient> {
   return new Promise((resolve, reject) => {
     const socket = new net.Socket();
     let pingTimer: NodeJS.Timer;
-    socket.setKeepAlive(true, 10000);
     socket.connect(7147, COORDINATOR_HOST);
     socket.on("connect", () => {
       socket.write(

--- a/templates/base/server/.hathora/protocol.ts.hbs
+++ b/templates/base/server/.hathora/protocol.ts.hbs
@@ -7,8 +7,13 @@ const SUBSCRIBE_USER = 1;
 const UNSUBSCRIBE_USER = 2;
 const HANDLE_UPDATE = 3;
 
-const STATE_UPDATE = 0;
-const STATE_NOT_FOUND = 1;
+enum STORE_MESSAGES {
+  STATE_UPDATE = 0,
+  STATE_NOT_FOUND = 1,
+  PING = 2,
+}
+
+const PING_INTERVAL_MS = 10000;
 
 type StateId = bigint;
 type UserId = string;
@@ -31,6 +36,7 @@ function readData(socket: net.Socket, onData: (data: Buffer) => void) {
 export function register(store: Store): Promise<CoordinatorClient> {
   return new Promise((resolve, reject) => {
     const socket = new net.Socket();
+    let pingTimer: NodeJS.Timer;
     socket.setKeepAlive(true, 10000);
     socket.connect(7147, COORDINATOR_HOST);
     socket.on("connect", () => {
@@ -51,14 +57,22 @@ export function register(store: Store): Promise<CoordinatorClient> {
       console.log(
         `Connected to coordinator at ${COORDINATOR_HOST} with appId {{appId}}`
       );
-      resolve(new CoordinatorClient(socket));
+      const coordinatorClient = new CoordinatorClient(socket);
+      pingTimer = setInterval(() => coordinatorClient.ping(), PING_INTERVAL_MS);
+      resolve(coordinatorClient);
     });
     socket.on("error", (err) => {
       console.error("Coordinator connection error", err);
+      if (pingTimer !== undefined) {
+        clearInterval(pingTimer);
+      }
       reject(err.message);
     });
     socket.on("close", () => {
       console.error("Coordinator connection closed, retrying...");
+      if (pingTimer !== undefined) {
+        clearInterval(pingTimer);
+      }
       setTimeout(() => socket.connect(7147, COORDINATOR_HOST), 1000 + Math.random() * 1000);
     });
     readData(socket, (data) => {
@@ -94,7 +108,7 @@ class CoordinatorClient {
     this.socket.write(
       new Writer()
         .writeUInt32(9 + userIdBuf.length + data.length)
-        .writeUInt8(STATE_UPDATE)
+        .writeUInt8(STORE_MESSAGES.STATE_UPDATE)
         .writeUInt64(stateId)
         .writeBuffer(userIdBuf)
         .writeBuffer(data)
@@ -107,9 +121,18 @@ class CoordinatorClient {
     this.socket.write(
       new Writer()
         .writeUInt32(9 + userIdBuf.length)
-        .writeUInt8(STATE_NOT_FOUND)
+        .writeUInt8(STORE_MESSAGES.STATE_NOT_FOUND)
         .writeUInt64(stateId)
         .writeBuffer(userIdBuf)
+        .toBuffer()
+    );
+  }
+
+  public ping() {
+    this.socket.write(
+      new Writer()
+        .writeUInt32(1)
+        .writeUInt8(STORE_MESSAGES.PING)
         .toBuffer()
     );
   }


### PR DESCRIPTION
TCP keepAlives aren't respected by some load balancers, so explicitly send a message every 10s to ensure the connection between a store and the coordinator stays alive.