### PR TITLE
Minor documentation fixes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -43,7 +43,7 @@ Requirements:
 
 - node v16.12.0+
 
-Install hathora from the npm registry:
+Install Hathora from the npm registry:
 
 ```sh
 npm install -g hathora

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,7 +46,7 @@ The coordinator also implements support for multiple protocols (although only We
 
 In a normal client/server set up, the client needs to connect directly to the server's IP address. This means that the server needs to advertise their IP to allow inbound connections, which can be a security risk (and some firewalls may prevent it).
 
-With Hathora, servers only need one output TCP connection to the coordinator -- all comunication is done through this connection. This allows the server's IP address to remain private and you don't need to allow any inbound connections.
+With Hathora, servers only need one output TCP connection to the coordinator -- all communication is done through this connection. This allows the server's IP address to remain private and you don't need to allow any inbound connections.
 
 ### Stream multiplexing
 
@@ -58,11 +58,11 @@ The coordinator knows data about backend instance health, active client connecti
 
 ## Data Privacy and Offline Development
 
-There is a production cloud coordinator instance deployed at coordinator.hathora.dev, mainted by the Hathora team.
+There is a production cloud coordinator instance deployed at coordinator.hathora.dev, maintained by the Hathora team.
 
 The coordinator does not store any game data -- that lives entirely within the backend instances which you own. The coordinator simply proxies game packets back and forth from clients and backend instances. The coordinator does store user profile information in order to allow Hathora applications to perform userId lookups.
 
-To develop locally without using the cloud coordinator (e.g. for working offline), you can make use of the [local coordinator](https://github.com/hathora/local-coordinator). Simply start the local coordinator process in a separate terminal tab, then set the `COORDINATOR_HOST` environment variable when starting the hathora dev server:
+To develop locally without using the cloud coordinator (e.g. for working offline), you can make use of the [local coordinator](https://github.com/hathora/local-coordinator). Simply start the local coordinator process in a separate terminal tab, then set the `COORDINATOR_HOST` environment variable when starting the Hathora dev server:
 
 ```sh
 COORDINATOR_HOST=localhost hathora dev

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -21,7 +21,7 @@ auth:
 
 ### Google login
 
-This methods allows users to login using their google account. Provided that the user consents to the Google OAuth prompt, it fetches basic information from their profile like their name and email address.
+This methods allows users to login using their Google account. Provided that the user consents to the Google OAuth prompt, it fetches basic information from their profile like their name and email address.
 
 To configure it, [create authorization credentials](https://developers.google.com/identity/sign-in/web/sign-in#create_authorization_credentials) from the Google developer console and simply paste the client ID you get into your `hathora.yml` as follows:
 

--- a/docs/client.md
+++ b/docs/client.md
@@ -1,6 +1,6 @@
 # Client
 
-The hathora framework includes an automatically generated [prototype UI](type-driven-development.md?id=prototype-ui) that lets you interact with your application and test your backend logic without writing any frontend code. Furthermore, hathora provides ways to incrementally add custom presentation logic as you become ready for it.
+The Hathora framework includes an automatically generated [prototype UI](type-driven-development.md?id=prototype-ui) that lets you interact with your application and test your backend logic without writing any frontend code. Furthermore, Hathora provides ways to incrementally add custom presentation logic as you become ready for it.
 
 ## Plugins
 
@@ -16,9 +16,9 @@ Plugins receive the following properties as input:
 
 - val -- this is the value you are rendering, it has the type of your filename
 - state -- this is the entire state tree, it has the type of `userState`
-- client -- this is the hathora client instance (so you can make method calls from within your plugin), with type `HathoraClient`
+- client -- this is the Hathora client instance (so you can make method calls from within your plugin), with type `HathoraClient`
 
-Example (from uno, using Lit):
+Example (from Uno, using Lit):
 
 ```js
 // Card.ts
@@ -56,10 +56,10 @@ Which renders like this in the prototype UI:
 
 ## Fully custom frontend
 
-When you're ready to move away from the debug app, simply create a new folder (you can name it anything you want) inside the `client` directory with an `index.html` file inside. This file now serves as the entry point to your frontend at http://localhost:3001, and can load code and other resources as needed. You are free to use any technologies you wish to build your frontend, just make sure to import the generated client to communicate with the hathora server.
+When you're ready to move away from the debug app, simply create a new folder (you can name it anything you want) inside the `client` directory with an `index.html` file inside. This file now serves as the entry point to your frontend at http://localhost:3001, and can load code and other resources as needed. You are free to use any technologies you wish to build your frontend, just make sure to import the generated client to communicate with the Hathora server.
 
 The `hathora` frontend tooling is built around [vite](https://vitejs.dev/), which generally creates for a pleasant development experience.
 
-For an example of a fully custom frontend built using hathora and PIXI.js, see https://github.com/hathora/ship-battle.
+For an example of a fully custom frontend built using Hathora and PIXI.js, see https://github.com/hathora/ship-battle.
 
 For an example using React, see https://github.com/hpx7/tussie-mussie.

--- a/docs/hathora-yml.md
+++ b/docs/hathora-yml.md
@@ -51,7 +51,7 @@ methods:
 
 ## auth
 
-The `auth` section is used to configure the authentication modes that the application can use. The two currently supported modes are anonymous and google. At least one authentication method must be configured.
+The `auth` section is used to configure the authentication modes that the application can use. The two currently supported modes are `anonymous` and `google`. At least one authentication method must be configured.
 
 Example:
 
@@ -82,4 +82,4 @@ The `error` key represents the response type the server sends when a method call
 
 ## tick
 
-The optional `tick` configures whether or not the backend will run an `onTick` function at a configurable interval. See the Server section below for more details.
+The optional `tick` configures whether or not the backend will run an `onTick` function at a configurable interval. See the [Server](server.md) section below for more details.

--- a/docs/state.md
+++ b/docs/state.md
@@ -12,7 +12,7 @@ The `userState` is the client specific view of the data which is kept synchroniz
 
 New states are created via the `/<appId>/create` endpoint in the coordinator. Users can directly create a new state by hitting this endpoint via `client.create(token, request)`, or they can go through the matchmaker via `client.findMatch(token, request, numPlayers)`. The matchmaker is responsible for grouping a set of users together based on the specified criteria, and then calling the create endpoint internally and returning the resulting `stateId` to the matched group.
 
-States are never destroyed, so they can always be accessed via their `stateId`. When there are no connected users to a given state, hathora may purge the `InternalState` from memory, but it will be loaded again from disk if someone connects to it again.
+States are never destroyed, so they can always be accessed via their `stateId`. When there are no connected users to a given state, Hathora may purge the `InternalState` from memory, but it will be loaded again from disk if someone connects to it again.
 
 ## Data privacy
 

--- a/docs/tutorial_among_us.md
+++ b/docs/tutorial_among_us.md
@@ -13,7 +13,7 @@ This is what our game will look like by the end of this tutorial:
 
 ## Install
 
-Before you begin, make sure you have nodejs v16.12+ and the hathora cli installed:
+Before you begin, make sure you have nodejs v16.12+ and the Hathora cli installed:
 
 ```sh
 npm install -g hathora
@@ -128,7 +128,7 @@ Because of the default implementation, we don't see any real data and clicking S
 
 See [here](methods) for more details about how server methods works.
 
-> The hathora dev server supports hot reloading of both backend and frontend, so you shouldn't need to restart the server when making edits to your code.
+> The Hathora dev server supports hot reloading of both backend and frontend, so you shouldn't need to restart the server when making edits to your code.
 
 Going back to the prototype UI, we can see our working application in action. Login, create a game, and join it as another user from a different tab. You should be able to see both users get added to the players array.
 

--- a/docs/tutorial_uno.md
+++ b/docs/tutorial_uno.md
@@ -12,7 +12,7 @@ This is what our game will look like by the end of this tutorial:
 
 ## Install
 
-Before you begin, make sure you have nodejs v16.12+ and the hathora cli installed:
+Before you begin, make sure you have nodejs v16.12+ and the Hathora cli installed:
 
 ```sh
 npm install -g hathora
@@ -56,7 +56,7 @@ userState: PlayerState
 error: string
 ```
 
-This file defines the client data model and the server api endpoints for our application. For more information on this file format, see [here](type-driven-development).
+This file defines the client data model and the server api endpoints for our application. For more information on this file format, see [here](type-driven-development.md).
 
 To initialize our project structure run `hathora init`. You should see the following directory structure generated for you:
 
@@ -120,7 +120,7 @@ Next, run `hathora dev` to start the development server. Visit http://localhost:
 
 ## Backend logic
 
-Because of the default implementation, we don't see any real data and clicking Submit for any of the methods displays a "Not implemented" error. Let's fix this by adding our game logic to `server/impl.ts`:
+Because of the default implementation, we don't see any real data and clicking `Submit` for any of the methods displays a "Not implemented" error. Let's fix this by adding our game logic to `server/impl.ts`:
 
 ```ts
 import { Methods, Context } from "./.hathora/methods";
@@ -212,9 +212,9 @@ export class Impl implements Methods<InternalState> {
 
 ```
 
-See [here](methods) for more details about how server methods works.
+See [here](methods.md) for more details about how server methods works.
 
-> The hathora dev server supports hot reloading of both backend and frontend, so you shouldn't need to restart the server when making edits to your code.
+> The Hathora dev server supports hot reloading of both backend and frontend, so you shouldn't need to restart the server when making edits to your code.
 
 Going back to the prototype UI, we can see our working application in action. Create a game, join it as another user from a different tab (by using the same url), and start the game. You should see a view like this:
 
@@ -236,7 +236,7 @@ One problem with our current backend implementation is that there is no validati
   }
 ```
 
-Now, if you try to join a second time you will get a `Already joined` error on the screen. Try adding validations to the other functions as well. To see a complete implementation of the backend, see [the uno example](https://github.com/hathora/hathora/tree/develop/examples/uno).
+Now, if you try to join a second time you will get a `Already joined` error on the screen. Try adding validations to the other functions as well. To see a complete implementation of the backend, see [the Uno example](https://github.com/hathora/hathora/tree/develop/examples/uno).
 
 ## Next steps
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -10,7 +10,7 @@ import { generate } from "../generate";
 const cmd: CommandModule = {
   command: "init",
   aliases: ["initialize", "initialise"],
-  describe: "Creates a new hathora project",
+  describe: "Creates a new Hathora project",
   handler() {
     const { rootDir, serverDir } = getDirs();
 

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -5,7 +5,7 @@ import { start } from "../utils";
 const cmd: CommandModule = {
   command: "start",
   aliases: ["up", "s"],
-  describe: "Starts the hathora server",
+  describe: "Starts the Hathora server",
   builder: { only: { choices: ["client", "server"] } },
   handler(argv) {
     start(argv.only as "server" | "client" | undefined);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,7 +54,7 @@ export async function makeCloudApiRequest(
 export function getDirs() {
   const rootDir = findUp("hathora.yml");
   if (rootDir === undefined) {
-    throw new Error("Doesn't appear to be inside a hathora project");
+    throw new Error("Doesn't appear to be inside a Hathora project");
   }
   return {
     rootDir,


### PR DESCRIPTION
Update some minor documentation issues, e.g. always capitalize `Hathora`, standardize `.md` in markdown links, and address a few typos