### PR TITLE
Add net to client package.json

### DIFF
--- a/templates/base/client/.hathora/package.json
+++ b/templates/base/client/.hathora/package.json
@@ -6,6 +6,7 @@
     "get-random-values": "1.2.2",
     "isomorphic-ws": "4.0.1",
     "jwt-decode": "3.1.2",
+    "net": "1.0.2",
     "ws": "8.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Without this PR, a Webpack build spits out this error:
```
Compiled with problems:X

ERROR in ../.hathora/transport.ts 2:0-22

Module not found: Error: Can't resolve 'net' in 'client/.hathora'
```