### PR TITLE
add state change options

### DIFF
--- a/templates/base/server/.hathora/methods.ts.hbs
+++ b/templates/base/server/.hathora/methods.ts.hbs
@@ -1,3 +1,4 @@
+import { Options } from "on-change";
 import { Chance } from "chance";
 import { Response } from "../../api/base";
 import {
@@ -25,6 +26,7 @@ export interface Context {
   ) => void;
 }
 export interface Methods<T> {
+  stateChangeOptions?: Options;
   initialize(ctx: Context, request: IInitializeRequest): T;
   {{#each methods}}
   {{@key}}(state: T, userId: UserId, ctx: Context, request: {{makeRequestName @key}}): Response;

--- a/templates/base/server/.hathora/wrapper.ts.hbs
+++ b/templates/base/server/.hathora/wrapper.ts.hbs
@@ -18,7 +18,7 @@ export class ImplWrapper {
     monkeyPatchSideEffectFunctions(ctx);
     const state = prevImpl.initialize(ctx, IInitializeRequest.decode(argsBuffer));
     restoreSideEffectFunctions();
-    this.state = onChange(state, () => (this._changedAt = Date.now()));
+    this.state = onChange(state, () => (this._changedAt = Date.now()), { ...(prevImpl.stateChangeOptions || {}), pathAsArray: true });
   }
   public async getResult(userId: UserId, method: Method, ctx: Context, argsBuffer: ArrayBufferView) {
     monkeyPatchSideEffectFunctions(ctx);


### PR DESCRIPTION
This change allows developers to specify [onChange options](https://github.com/sindresorhus/on-change#options) to use when `onChange` is applied to their game state.

This is needed so developers can better control how changes are detected in their game state.

Example usage:
```
export class Impl implements Methods<Game> {
  stateChangeOptions = {
    ignoreKeys: ['engine']
  }

  initialize(): Game {
    return new Game()
  }

  ...

  getUserState(game: Game): UserState {
    return game.state
  }

  onTick(game: Game, ctx: Context, timeDelta: number): void {
    game.engine.run(timeDelta)
  }
}
```

Other reasonable names for this new property: `onChangeOptions`, `stateChangeDetection`, `stateChangeDetectionOptions`.