### PR TITLE
React class -> className in prototype-ui

### DIFF
--- a/templates/base/client/prototype-ui/State.tsx.hbs
+++ b/templates/base/client/prototype-ui/State.tsx.hbs
@@ -54,7 +54,7 @@ function ArrayDisplay<T>(props: { value: T[]; children: (value: T) => JSX.Elemen
             }`}
           >
             {props.value.map((val, i) => (
-              <div key={i} class="m-0.5">{props.children(val)}</div>
+              <div key={i} className="m-0.5">{props.children(val)}</div>
             ))}
           </div>
         </>


### PR DESCRIPTION
Noticed this while playing around with `hathora dev`, seeing errors in my browser's JS console. Typo here.