### PR TITLE
Add optional onUserJoin and onUserLeave hooks

### DIFF
--- a/templates/base/server/.hathora/methods.ts.hbs
+++ b/templates/base/server/.hathora/methods.ts.hbs
@@ -32,6 +32,8 @@ export interface Methods<T> {
   {{@key}}(state: T, userId: UserId, ctx: Context, request: {{makeRequestName @key}}): Response;
   {{/each}}
   getUserState(state: T, userId: UserId): UserState;
+  onUserJoin?(state: T, userId: UserId, ctx: Context): void;
+  onUserLeave?(state: T, userId: UserId, ctx: Context): void;
   {{#if tick}}
   onTick(state: T, ctx: Context, timeDelta: number): void;
   {{/if}}

--- a/templates/base/server/.hathora/store.ts.hbs
+++ b/templates/base/server/.hathora/store.ts.hbs
@@ -103,14 +103,17 @@ const store: Application = {
       }
     }
     sendSnapshot(roomId, userId);
+    const { impl, chance } = rooms.get(roomId)!;
+    impl._onUserJoin(userId, ctx(chance, Date.now(), roomId));
   },
   async unsubscribeUser(roomId: RoomId, userId: UserId): Promise<void> {
     if (!rooms.has(roomId)) {
       return;
     }
-    const subscribers = rooms.get(roomId)!.subscriptions;
-    subscribers.delete(userId);
-    if (subscribers.size === 0) {
+    const { impl, chance, subscriptions } = rooms.get(roomId)!;
+    impl._onUserLeave(userId, ctx(chance, Date.now(), roomId));
+    subscriptions.delete(userId);
+    if (subscriptions.size === 0) {
       changedStates.delete(roomId);
       pendingMessages.delete(roomId);
     }

--- a/templates/base/server/.hathora/wrapper.ts.hbs
+++ b/templates/base/server/.hathora/wrapper.ts.hbs
@@ -41,6 +41,18 @@ export class ImplWrapper {
     const impl = await getLatestImpl();
     return impl.getUserState(onChange.target(this.state), userId);
   }
+  public async _onUserJoin(userId: UserId, ctx: Context) {
+    const impl = await getLatestImpl();
+    if (impl.onUserJoin !== undefined) {
+      await impl.onUserJoin(this.state, userId, ctx);
+    }
+  }
+  public async _onUserLeave(userId: UserId, ctx: Context) {
+    const impl = await getLatestImpl();
+    if (impl.onUserLeave !== undefined) {
+      await impl.onUserLeave(this.state, userId, ctx);
+    }
+  }
   public changedAt(): number | undefined {
     const res = this._changedAt;
     this._changedAt = undefined;


### PR DESCRIPTION
I think this would help resolve #196.

Adds optional `onUserJoin` and `onUserLeave` methods to the `Methods` interface which can be implemented in `Impl` to react to users joining and leaving. This can be useful to clean up `InternalState` immediately when users leave.

For example, the Uno demo could be updated to remove that user's entry from `hands` in state if the user leaves (contrived example, obviously that wouldn't make sense in an IRL game of Uno because players can't really join/leave in the middle of a match).

Implementation detail: I used `_` prefixed methods in the wrapper because I think we should pass `this.state` through, and that seems to be the pattern used here.

I didn't test this yet because I didn't look into how to use this repo as-is, so this is probably WIP if it needs tests added or some code to be generated.