### PR TITLE
chore: upgrade openid-client to resolve outdated node warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "hot-esm": "1.5.0",
         "js-yaml": "4.1.0",
         "open": "8.4.0",
-        "openid-client": "5.1.8",
+        "openid-client": "5.4.2",
         "prompts": "2.4.2",
         "shelljs": "0.8.5",
         "tar": "6.1.11",
@@ -45,7 +45,7 @@
         "@types/yargs": "17.0.12",
         "@typescript-eslint/eslint-plugin": "5.33.0",
         "@typescript-eslint/parser": "5.43.0",
-        "docsify-cli": "^4.4.4",
+        "docsify-cli": "4.4.4",
         "eslint": "8.23.1",
         "eslint-plugin-import": "2.26.0",
         "eslint-plugin-prettier": "4.2.1",
@@ -4158,9 +4158,9 @@
       "dev": true
     },
     "node_modules/jose": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.8.1.tgz",
-      "integrity": "sha512-+/hpTbRcCw9YC0TOfN1W47pej4a9lRmltdOVdRLz5FP5UvUq3CenhXjQK7u/8NdMIIShMXYAh9VLPhc7TjhvFw==",
+      "version": "4.14.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.14.4.tgz",
+      "integrity": "sha512-j8GhLiKmUAh+dsFXlX1aJCbt5KMibuKb+d7j1JaOJG6s2UjX1PQlW+OKB/sD4a/5ZYF4RcmYmLSndOoU3Lt/3g==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -4811,9 +4811,9 @@
       }
     },
     "node_modules/oidc-token-hash": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.1.tgz",
-      "integrity": "sha512-EvoOtz6FIEBzE+9q253HsLCVRiK/0doEJ2HCvvqMQb3dHZrP3WlJKYtJ55CRTw4jmYomzH4wkPuCj/I3ZvpKxQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.3.tgz",
+      "integrity": "sha512-IF4PcGgzAr6XXSff26Sk/+P4KZFJVuHAJZj3wgO3vX2bMdNVp/QXTP3P7CEm9V1IdG8lDLY3HhiqpsE/nOwpPw==",
       "engines": {
         "node": "^10.13.0 || >=12.0.0"
       }
@@ -4864,17 +4864,14 @@
       }
     },
     "node_modules/openid-client": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.1.8.tgz",
-      "integrity": "sha512-EPxJY6bT7YIYQEXSGxRC5flQ3GUhLy98ufdto6+BVBrFGPmwjUpy4xBcYuU/Wt9nPkO/3EgljBrr6Ezx4lp1RQ==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.4.2.tgz",
+      "integrity": "sha512-lIhsdPvJ2RneBm3nGBBhQchpe3Uka//xf7WPHTIglery8gnckvW7Bd9IaQzekzXJvWthCMyi/xVEyGW0RFPytw==",
       "dependencies": {
-        "jose": "^4.1.4",
+        "jose": "^4.14.1",
         "lru-cache": "^6.0.0",
-        "object-hash": "^2.0.1",
-        "oidc-token-hash": "^5.0.1"
-      },
-      "engines": {
-        "node": "^12.19.0 || ^14.15.0 || ^16.13.0"
+        "object-hash": "^2.2.0",
+        "oidc-token-hash": "^5.0.3"
       },
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -9530,9 +9527,9 @@
       "dev": true
     },
     "jose": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.8.1.tgz",
-      "integrity": "sha512-+/hpTbRcCw9YC0TOfN1W47pej4a9lRmltdOVdRLz5FP5UvUq3CenhXjQK7u/8NdMIIShMXYAh9VLPhc7TjhvFw=="
+      "version": "4.14.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.14.4.tgz",
+      "integrity": "sha512-j8GhLiKmUAh+dsFXlX1aJCbt5KMibuKb+d7j1JaOJG6s2UjX1PQlW+OKB/sD4a/5ZYF4RcmYmLSndOoU3Lt/3g=="
     },
     "js-sdsl": {
       "version": "4.1.4",
@@ -10006,9 +10003,9 @@
       }
     },
     "oidc-token-hash": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.1.tgz",
-      "integrity": "sha512-EvoOtz6FIEBzE+9q253HsLCVRiK/0doEJ2HCvvqMQb3dHZrP3WlJKYtJ55CRTw4jmYomzH4wkPuCj/I3ZvpKxQ=="
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.3.tgz",
+      "integrity": "sha512-IF4PcGgzAr6XXSff26Sk/+P4KZFJVuHAJZj3wgO3vX2bMdNVp/QXTP3P7CEm9V1IdG8lDLY3HhiqpsE/nOwpPw=="
     },
     "on-finished": {
       "version": "2.3.0",
@@ -10044,14 +10041,14 @@
       "dev": true
     },
     "openid-client": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.1.8.tgz",
-      "integrity": "sha512-EPxJY6bT7YIYQEXSGxRC5flQ3GUhLy98ufdto6+BVBrFGPmwjUpy4xBcYuU/Wt9nPkO/3EgljBrr6Ezx4lp1RQ==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.4.2.tgz",
+      "integrity": "sha512-lIhsdPvJ2RneBm3nGBBhQchpe3Uka//xf7WPHTIglery8gnckvW7Bd9IaQzekzXJvWthCMyi/xVEyGW0RFPytw==",
       "requires": {
-        "jose": "^4.1.4",
+        "jose": "^4.14.1",
         "lru-cache": "^6.0.0",
-        "object-hash": "^2.0.1",
-        "oidc-token-hash": "^5.0.1"
+        "object-hash": "^2.2.0",
+        "oidc-token-hash": "^5.0.3"
       }
     },
     "optionator": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "hot-esm": "1.5.0",
     "js-yaml": "4.1.0",
     "open": "8.4.0",
-    "openid-client": "5.1.8",
+    "openid-client": "5.4.2",
     "prompts": "2.4.2",
     "shelljs": "0.8.5",
     "tar": "6.1.11",


### PR DESCRIPTION
Resolves this issue with an old version of openid-client.
```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'openid-client@5.1.8',
npm WARN EBADENGINE   required: { node: '^12.19.0 || ^14.15.0 || ^16.13.0' },
npm WARN EBADENGINE   current: { node: 'v20.1.0', npm: '9.6.4' }
npm WARN EBADENGINE }
```