### PR TITLE
feat: add room id to context

### DIFF
--- a/templates/base/server/.hathora/methods.ts.hbs
+++ b/templates/base/server/.hathora/methods.ts.hbs
@@ -1,5 +1,6 @@
 import { Options } from "on-change";
 import { Chance } from "chance";
+import { RoomId } from "@hathora/server-sdk";
 import { Response } from "../../api/base";
 import {
   UserId,
@@ -13,6 +14,7 @@ import {
 } from "../../api/types";
 
 export interface Context {
+  roomId: RoomId
   chance: ReturnType<typeof Chance>;
   time: number;
   sendEvent: <EventType extends HathoraEventTypes>(

--- a/templates/base/server/.hathora/store.ts.hbs
+++ b/templates/base/server/.hathora/store.ts.hbs
@@ -262,6 +262,7 @@ function sendMessages(stateId: RoomId, userId: UserId) {
 
 function ctx(chance: Chance.Chance, time: number, stateId: RoomId): Context {
   return {
+    roomId: stateId,
     chance,
     time,
     sendEvent<EventType extends HathoraEventTypes>(


### PR DESCRIPTION
**Problem**

It's currently not possible to shut down a specific room in builder, you can only shut down the whole process which will bring down all the rooms on that process. In order to make sure rooms don't live forever when errant connections remain we should be able to shut down a specific room.

**Proposed Solution**

Add `roomId` to the context object so the the Rooms API can be called to shutdown the current room.
Example: `https://api.hathora.dev/rooms/v2/{appId}/destroy/{roomId}`